### PR TITLE
Append source auth flag to lotus trace

### DIFF
--- a/node/config/types.go
+++ b/node/config/types.go
@@ -311,6 +311,7 @@ type Pubsub struct {
 	RemoteTracer          string
 	JsonTracerFile        string
 	ElasticSearchTracer   string
+	TracerSourceAuth      string
 }
 
 type Chainstore struct {

--- a/node/modules/lp2p/pubsub.go
+++ b/node/modules/lp2p/pubsub.go
@@ -384,7 +384,7 @@ func GossipSub(in GossipIn) (service *pubsub.PubSub, err error) {
 		}
 		transports = append(transports, elasticSearchTransport)
 	}
-	lt := tracer.NewLotusTracer(transports, in.Host.ID())
+	lt := tracer.NewLotusTracer(transports, in.Host.ID(), in.Cfg.TracerSourceAuth)
 
 	// tracer
 	if in.Cfg.RemoteTracer != "" {

--- a/node/modules/tracer/tracer.go
+++ b/node/modules/tracer/tracer.go
@@ -11,16 +11,18 @@ import (
 
 var log = logging.Logger("lotus-tracer")
 
-func NewLotusTracer(tt []TracerTransport, pid peer.ID) LotusTracer {
+func NewLotusTracer(tt []TracerTransport, pid peer.ID, sourceAuth string) LotusTracer {
 	return &lotusTracer{
 		tt:  tt,
 		pid: pid,
+		sa:  sourceAuth,
 	}
 }
 
 type lotusTracer struct {
 	tt  []TracerTransport
 	pid peer.ID
+	sa  string
 }
 
 const (
@@ -32,6 +34,7 @@ type LotusTraceEvent struct {
 	PeerID     []byte                    `json:"peerID,omitempty"`
 	Timestamp  *int64                    `json:"timestamp,omitempty"`
 	PeerScores *TraceEvent_PeerScores    `json:"peerScores,omitempty"`
+	SourceAuth string                    `json:"sourceAuth,omitempty"`
 }
 
 type TraceEvent_PeerScores struct {
@@ -48,9 +51,10 @@ type LotusTracer interface {
 func (lt *lotusTracer) PeerScores(scores map[peer.ID]*pubsub.PeerScoreSnapshot) {
 	now := time.Now().UnixNano()
 	evt := &LotusTraceEvent{
-		Type:      *TraceEvent_PEER_SCORES.Enum(),
-		PeerID:    []byte(lt.pid),
-		Timestamp: &now,
+		Type:       *TraceEvent_PEER_SCORES.Enum(),
+		PeerID:     []byte(lt.pid),
+		Timestamp:  &now,
+		SourceAuth: lt.sa,
 		PeerScores: &TraceEvent_PeerScores{
 			Scores: scores,
 		},


### PR DESCRIPTION
 - add tracer source auth configuration so we can weight scores from trusted nodes